### PR TITLE
Update the operator sdk to 1.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:32
 
-ARG operator_sdk_version=v1.9.0
+ARG operator_sdk_version=v1.13.1
 
 RUN  yum install -y \
 	--setopt=install_weak_deps=False \

--- a/scorecard-basic-config.yml
+++ b/scorecard-basic-config.yml
@@ -5,14 +5,14 @@ metadata:
 stages:
 - parallel: true
   tests:
-  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+  - image: quay.io/operator-framework/scorecard-test:v1.13.1
     entrypoint:
     - scorecard-test
     - basic-check-spec
     labels:
       suite: basic
       test: basic-check-spec-test
-  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+  - image: quay.io/operator-framework/scorecard-test:v1.13.1
     entrypoint:
     - scorecard-test
     - olm-bundle-validation


### PR DESCRIPTION
This takes care of third objective in CVP-2382:

> - Update the operator-utils container to use operator-sdk >= v1.13.0
> - Update the operator-test-playbooks to use operator-sdk >= v1.13.0
> - **Update the operator-sdk image used in the Prow workflow to use operator-sdk >= v1.13.0**
> - Update the quay.io/operator-framework/scorecard-test images to use v1.13.0 tag