### PR TITLE
[CVP-2977] Upgrade operator-sdk to v1.26.0 for operator bundle testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:37
 
-ARG operator_sdk_version=v1.16.0
+ARG operator_sdk_version=v1.26.0
 
 RUN  yum install -y \
 	--setopt=install_weak_deps=False \

--- a/scorecard-basic-config.yml
+++ b/scorecard-basic-config.yml
@@ -5,14 +5,14 @@ metadata:
 stages:
 - parallel: true
   tests:
-  - image: quay.io/operator-framework/scorecard-test:v1.16.0
+  - image: quay.io/operator-framework/scorecard-test:v1.26.0
     entrypoint:
     - scorecard-test
     - basic-check-spec
     labels:
       suite: basic
       test: basic-check-spec-test
-  - image: quay.io/operator-framework/scorecard-test:v1.16.0
+  - image: quay.io/operator-framework/scorecard-test:v1.26.0
     entrypoint:
     - scorecard-test
     - olm-bundle-validation


### PR DESCRIPTION
Downstream changes will be merged first

From CVP-2977 deliverables, this MR takes care of the highlighted ones:

- Update the operator-utils container to use operator-sdk >= v1.26.0 and add the new images to the image source test allow-list
- Run the operator-bundle-retest pipeline (skip deploy) on the MR to the cvp/pipeline repository
- Update the operator-test-playbooks to use operator-sdk >= v1.26.0
- **Update the operator-scorecard-test-container image to use operator-sdk >= v1.26.0**
- Build and push the updated operator-scorecard-test-container image to the quay.io/operator-framework/scorecard-test repository